### PR TITLE
fix: correct lua syntax for autocmd example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ in `~/.config/nvim/ftdetect/angular.vim`, or put
 ```
 vim.filetype.add({
     extension = {
-        component.html = "angular"
+        ["component.html"] = "angular"
     }
 })
 ```


### PR DESCRIPTION
When adding this as described there was a lua syntax error since `.` is not a valid character when defining keys like this.
I believe this is what you had intended.

Also, how do you run this? I was looking for some `.lua` entrypoint or something I could load with lazy.nvim but I haven't seen one.