### PR TITLE
fix: linker errors when using in other projects

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -13,11 +13,11 @@ fn main() {
     // If your language uses an external scanner written in C,
     // then include this block of code:
 
-    /*
+    
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
+    
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());


### PR DESCRIPTION
When I was trying to add this tree-sitter to zed, I ran into the following issue
```
 ld: warning: Could not find or use auto-linked framework 'CoreAudioTypes': framework 'CoreAudioTypes' not found
          ld: Undefined symbols:
            _tree_sitter_angular_external_scanner_create, referenced from:
                _tree_sitter_angular.language in libtree_sitter_angular-a48ca032137ae057.rlib[4](parser.o)
            _tree_sitter_angular_external_scanner_deserialize, referenced from:
                _tree_sitter_angular.language in libtree_sitter_angular-a48ca032137ae057.rlib[4](parser.o)
            _tree_sitter_angular_external_scanner_destroy, referenced from:
                _tree_sitter_angular.language in libtree_sitter_angular-a48ca032137ae057.rlib[4](parser.o)
            _tree_sitter_angular_external_scanner_scan, referenced from:
                _tree_sitter_angular.language in libtree_sitter_angular-a48ca032137ae057.rlib[4](parser.o)
            _tree_sitter_angular_external_scanner_serialize, referenced from:
                _tree_sitter_angular.language in libtree_sitter_angular-a48ca032137ae057.rlib[4](parser.o)
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Removing the comment for the scanner_path seems to fix that build issue when importing this library as a lib into other projects. 