### PR TITLE
Make tree-sitter.json and WASM prebuild available in npm release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-angular"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-angular"
 description = "Angular grammar for tree-sitter"
-version = "0.6.2"
+version = "0.6.3"
 keywords = ["incremental", "parsing", "angular"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-angular"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-angular",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-angular",
-      "version": "0.6.1",
+      "version": "0.6.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-angular",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Tree-sitter grammar for the Angular framework",
   "main": "bindings/node",
   "types": "bindings/node",
@@ -26,11 +26,13 @@
   ],
   "files": [
     "grammar.js",
+    "tree-sitter.json",
     "binding.gyp",
     "prebuilds/**",
     "bindings/node/*",
     "queries/*",
-    "src/**"
+    "src/**",
+    "*.wasm"
   ],
   "author": "Dennis van den Berg",
   "url": "https://vdberg.dev",

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -9,7 +9,7 @@
     }
   ],
   "metadata": {
-    "version": "0.6.0",
+    "version": "0.6.3",
     "license": "MIT",
     "description": "Tree-sitter grammar for the Angular framework",
     "authors": [


### PR DESCRIPTION
Referencing [`tree-sitter-c-sharp`](https://github.com/tree-sitter/tree-sitter-c-sharp/blob/b5eb5742f6a7e9438bee22ce8026d6b927be2cd7/package.json#L29-L38), I think you just have to add them to the files section of `package.json`.

I haven't been able to test this, but I'm fairly sure this should do what I want.